### PR TITLE
Include non-Ruby files in gem package

### DIFF
--- a/rack-allocation_stats.gemspec
+++ b/rack-allocation_stats.gemspec
@@ -10,8 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Rack middleware for tracing object allocations in Ruby 2.1"
   spec.description   = "Rack middleware for tracing object allocations in Ruby 2.1"
 
-  #spec.files         = `git ls-files`.split("\n")
-  spec.files         = `find . -path "*.rb"`.split("\n")
+  spec.files         = Dir.glob('{lib,spec}/**/*') + %w[LICENSE README.markdown TODO.markdown]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "allocation_stats"


### PR DESCRIPTION
The interactive mode was not working because the gem package did not contain the non-Ruby files needed to run it. This commit opens up the file inclusion to anything under lib and spec. This error does not present itself if you depend on the gem using either git or a path dependency in bundler.

The error I was getting was:

```
!! Unexpected error while processing request: No such file or directory @ rb_sysopen - /home/vagrant/.rvm/gems/ruby-2.1.0/gems/rack-allocation_stats-0.1.1/lib/rack/allocation_stats/formatters/../interactive/index.html.erb
```
